### PR TITLE
Improve data hydration and seed content

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,11 +1,11 @@
-import { PrismaClient } from "../src/generated/prisma";
-import bcrypt from "bcryptjs";
+import { PrismaClient } from '../src/generated/prisma';
+import bcrypt from 'bcryptjs';
 
 const prisma = new PrismaClient();
 
 async function ensureAdmin() {
-  const adminEmail = process.env.SEED_ADMIN_EMAIL || "admin@orna.local";
-  const adminPassword = process.env.SEED_ADMIN_PASSWORD || "ChangeMe123!";
+  const adminEmail = process.env.SEED_ADMIN_EMAIL || 'admin@orna.local';
+  const adminPassword = process.env.SEED_ADMIN_PASSWORD || 'ChangeMe123!';
   const existing = await prisma.user.findUnique({
     where: { email: adminEmail },
   });
@@ -15,8 +15,8 @@ async function ensureAdmin() {
   const user = await prisma.user.create({
     data: {
       email: adminEmail,
-      name: "Admin",
-      role: "ADMIN",
+      name: 'Admin',
+      role: 'ADMIN',
       image: undefined,
     },
   });
@@ -29,123 +29,289 @@ async function ensureAdmin() {
 }
 
 async function main() {
-  console.log("🌱 Starting database seed...");
+  console.log('🌱 Starting database seed...');
 
   // Clear existing data
   await prisma.orderItem.deleteMany();
   await prisma.order.deleteMany();
   await prisma.contact.deleteMany();
   await prisma.product.deleteMany();
+  await prisma.setting.deleteMany();
   await prisma.user.deleteMany();
 
   // Ensure admin
   const admin = await ensureAdmin();
   console.log(`✅ Seeded admin: ${admin.email}`);
 
+  // Seed baseline store settings used across the storefront
+  await Promise.all([
+    prisma.setting.upsert({
+      where: { key: 'store:name' },
+      update: { value: 'Orna Fine Jewelry' },
+      create: { key: 'store:name', value: 'Orna Fine Jewelry' },
+    }),
+    prisma.setting.upsert({
+      where: { key: 'store:currency' },
+      update: { value: 'LYD' },
+      create: { key: 'store:currency', value: 'LYD' },
+    }),
+    prisma.setting.upsert({
+      where: { key: 'store:deliveryRegion' },
+      update: { value: 'Tripoli & Surrounding Cities' },
+      create: {
+        key: 'store:deliveryRegion',
+        value: 'Tripoli & Surrounding Cities',
+      },
+    }),
+    prisma.setting.upsert({
+      where: { key: 'store:contactPhone' },
+      update: { value: '+218 91 123 4567' },
+      create: { key: 'store:contactPhone', value: '+218 91 123 4567' },
+    }),
+    prisma.setting.upsert({
+      where: { key: 'store:contactEmail' },
+      update: { value: 'care@orna.ly' },
+      create: { key: 'store:contactEmail', value: 'care@orna.ly' },
+    }),
+    prisma.setting.upsert({
+      where: { key: 'store:social' },
+      update: {
+        value: {
+          instagram: 'https://instagram.com/orna.jewelry',
+          facebook: 'https://facebook.com/orna.jewelry',
+          whatsapp: 'https://wa.me/218911234567',
+        },
+      },
+      create: {
+        key: 'store:social',
+        value: {
+          instagram: 'https://instagram.com/orna.jewelry',
+          facebook: 'https://facebook.com/orna.jewelry',
+          whatsapp: 'https://wa.me/218911234567',
+        },
+      },
+    }),
+  ]);
+
+  console.log('✅ Seeded core store settings');
+
   // Create products
   const products = await Promise.all([
     prisma.product.create({
       data: {
         name: {
-          ar: "خاتم الأمل الذهبي",
-          en: "Golden Hope Ring",
+          ar: 'خاتم الأمل الذهبي',
+          en: 'Golden Hope Ring',
         },
-        slug: "golden-hope-ring",
+        slug: 'golden-hope-ring',
         description: {
-          ar: "خاتم ذهبي عيار 18 قيراط مطعم بالألماس الطبيعي، يرمز للأمل والنور في حياتك",
-          en: "18k gold ring adorned with natural diamonds, symbolizing hope and light in your life",
+          ar: 'خاتم ذهبي عيار 18 قيراط مطعم بالألماس الطبيعي، يرمز للأمل والنور في حياتك',
+          en: '18k gold ring adorned with natural diamonds, symbolizing hope and light in your life',
         },
         subtitle: {
-          ar: "تصميم أنيق ومميز",
-          en: "Elegant and distinctive design",
+          ar: 'تصميم أنيق ومميز',
+          en: 'Elegant and distinctive design',
         },
         price: 1850,
         priceBeforeDiscount: 2100,
         wrappingPrice: 100,
-        images: ["/orna/خاتم الآمل(1).JPG", "/orna/1.jpeg"],
+        images: ['/orna/خاتم الآمل(1).JPG', '/orna/1.jpeg'],
         featured: true,
-        status: "ACTIVE",
+        stockQuantity: 8,
+        status: 'ACTIVE',
       },
     }),
     prisma.product.create({
       data: {
         name: {
-          ar: "عقد لؤلؤ التاهيتي",
-          en: "Tahitian Pearl Necklace",
+          ar: 'عقد لؤلؤ التاهيتي',
+          en: 'Tahitian Pearl Necklace',
         },
-        slug: "tahitian-pearl-necklace",
+        slug: 'tahitian-pearl-necklace',
         description: {
-          ar: "عقد من لؤلؤ التاهيتي الطبيعي الفاخر مع إغلاق من الذهب الأبيض",
-          en: "Luxurious natural Tahitian pearl necklace with white gold clasp",
+          ar: 'عقد من لؤلؤ التاهيتي الطبيعي الفاخر مع إغلاق من الذهب الأبيض',
+          en: 'Luxurious natural Tahitian pearl necklace with white gold clasp',
         },
         price: 3200,
         wrappingPrice: 150,
-        images: ["/orna/سلسال اللؤلؤ التاهيتي مع الباروك.JPG", "/orna/2.jpeg"],
+        images: ['/orna/سلسال اللؤلؤ التاهيتي مع الباروك.JPG', '/orna/2.jpeg'],
         featured: true,
-        status: "ACTIVE",
+        stockQuantity: 5,
+        status: 'ACTIVE',
       },
     }),
     prisma.product.create({
       data: {
         name: {
-          ar: "طقم الطاووس الأبيض",
-          en: "White Peacock Set",
+          ar: 'طقم الطاووس الأبيض',
+          en: 'White Peacock Set',
         },
-        slug: "white-peacock-set",
+        slug: 'white-peacock-set',
         description: {
-          ar: "طقم كامل من الذهب الأبيض والماس يشمل عقد وأقراط وخاتم",
-          en: "Complete set of white gold and diamonds including necklace, earrings, and ring",
+          ar: 'طقم كامل من الذهب الأبيض والماس يشمل عقد وأقراط وخاتم',
+          en: 'Complete set of white gold and diamonds including necklace, earrings, and ring',
         },
         subtitle: {
-          ar: "رمز النقاء والخلود",
-          en: "Symbol of purity and eternity",
+          ar: 'رمز النقاء والخلود',
+          en: 'Symbol of purity and eternity',
         },
         price: 4500,
         priceBeforeDiscount: 5000,
         wrappingPrice: 200,
         images: [
-          "/orna/طقم الطاووس الآبيض.JPG",
-          "/orna/3.jpeg",
-          "/orna/4.jpeg",
+          '/orna/طقم الطاووس الآبيض.JPG',
+          '/orna/3.jpeg',
+          '/orna/4.jpeg',
         ],
         featured: true,
-        status: "ACTIVE",
+        stockQuantity: 3,
+        status: 'ACTIVE',
       },
     }),
     prisma.product.create({
       data: {
         name: {
-          ar: "أقراط الماس الكلاسيكية",
-          en: "Classic Diamond Earrings",
+          ar: 'أقراط الماس الكلاسيكية',
+          en: 'Classic Diamond Earrings',
         },
-        slug: "classic-diamond-earrings",
+        slug: 'classic-diamond-earrings',
         description: {
-          ar: "أقراط كلاسيكية من الذهب الأبيض مطعمة بالألماس الطبيعي",
-          en: "Classic white gold earrings studded with natural diamonds",
+          ar: 'أقراط كلاسيكية من الذهب الأبيض مطعمة بالألماس الطبيعي',
+          en: 'Classic white gold earrings studded with natural diamonds',
         },
         price: 2800,
         wrappingPrice: 120,
-        images: ["/orna/5.jpeg", "/orna/6.jpeg"],
+        images: ['/orna/5.jpeg', '/orna/6.jpeg'],
         featured: false,
-        status: "ACTIVE",
+        stockQuantity: 10,
+        status: 'ACTIVE',
       },
     }),
     prisma.product.create({
       data: {
         name: {
-          ar: "سوار الوردة الذهبية",
-          en: "Golden Rose Bracelet",
+          ar: 'سوار الوردة الذهبية',
+          en: 'Golden Rose Bracelet',
         },
-        slug: "golden-rose-bracelet",
+        slug: 'golden-rose-bracelet',
         description: {
-          ar: "سوار ذهبي على شكل وردة بتصميم أنثوي راقي",
-          en: "Golden rose-shaped bracelet with elegant feminine design",
+          ar: 'سوار ذهبي على شكل وردة بتصميم أنثوي راقي',
+          en: 'Golden rose-shaped bracelet with elegant feminine design',
         },
         price: 1650,
         wrappingPrice: 80,
-        images: ["/orna/7.jpeg", "/orna/8.jpeg"],
+        images: ['/orna/7.jpeg', '/orna/8.jpeg'],
         featured: false,
-        status: "ACTIVE",
+        stockQuantity: 12,
+        status: 'ACTIVE',
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: {
+          ar: 'سلسال آفردويت المتدلي',
+          en: 'Aphrodite Cascade Necklace',
+        },
+        slug: 'aphrodite-cascade-necklace',
+        description: {
+          ar: 'سلسال فاخر مرصع بالكريستال اللامع يعكس بريقاً أنثوياً ساحراً',
+          en: 'A luxurious necklace adorned with shimmering crystals that radiate feminine allure.',
+        },
+        subtitle: {
+          ar: 'بريق لا ينسى',
+          en: 'Unforgettable brilliance',
+        },
+        price: 2350,
+        priceBeforeDiscount: 2590,
+        wrappingPrice: 120,
+        images: ['/orna/سلسال آفروديت.JPG', '/orna/333.jpg'],
+        featured: true,
+        stockQuantity: 6,
+        status: 'ACTIVE',
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: {
+          ar: 'قلادة المفتاح الملكي',
+          en: 'Heritage Key Pendant',
+        },
+        slug: 'heritage-key-pendant',
+        description: {
+          ar: 'قلادة ذهبية تعكس إرثاً عريقاً بتفاصيل محفورة يدوياً',
+          en: 'A gold pendant celebrating timeless heritage with meticulously hand-engraved details.',
+        },
+        price: 980,
+        wrappingPrice: 65,
+        images: ['/orna/سلسال المفتاح.JPG', '/orna/444.jpg'],
+        featured: false,
+        stockQuantity: 15,
+        status: 'ACTIVE',
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: {
+          ar: 'طقم الحديقة الليلية',
+          en: 'Midnight Garden Set',
+        },
+        slug: 'midnight-garden-set',
+        description: {
+          ar: 'طقم متكامل من الذهب الوردي والأحجار الداكنة مستوحى من جمال الحدائق الليلية',
+          en: 'A complete rose-gold set with deep gemstones inspired by the mystery of midnight gardens.',
+        },
+        subtitle: {
+          ar: 'سحر الألوان الدافئة',
+          en: 'Warm, enchanting hues',
+        },
+        price: 3820,
+        priceBeforeDiscount: 4200,
+        wrappingPrice: 180,
+        images: ['/orna/طقم الحديقة السرية.jpg', '/orna/66.jpg'],
+        featured: false,
+        stockQuantity: 4,
+        status: 'ACTIVE',
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: {
+          ar: 'طقم بلوسوم الفاخر',
+          en: 'Blossom Ribbon Set',
+        },
+        slug: 'blossom-ribbon-set',
+        description: {
+          ar: 'طقم أنيق يجمع بين الأقراط والقلادة بتصميم مستوحى من شرائط الزهور',
+          en: 'An elegant set pairing earrings and necklace with ribbon-inspired floral motifs.',
+        },
+        price: 2950,
+        wrappingPrice: 140,
+        images: ['/orna/طقم بلوسوم.JPG', '/orna/طقم الفيونكة.jpg'],
+        featured: true,
+        stockQuantity: 7,
+        status: 'ACTIVE',
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: {
+          ar: 'طقم اللؤلؤ الباروك',
+          en: 'Baroque Pearl Suite',
+        },
+        slug: 'baroque-pearl-suite',
+        description: {
+          ar: 'مجموعة فاخرة من اللآلئ الطبيعية بتصميم كلاسيكي يعكس الفخامة العصرية',
+          en: 'A lavish ensemble of natural baroque pearls crafted for modern sophistication.',
+        },
+        price: 4100,
+        wrappingPrice: 160,
+        images: [
+          '/orna/طقم لؤلؤ الباروك.JPG',
+          '/orna/طقم لؤلؤ الباروك التاهيتي.jpg',
+        ],
+        featured: true,
+        stockQuantity: 5,
+        status: 'ACTIVE',
       },
     }),
   ]);
@@ -156,22 +322,33 @@ async function main() {
   const contacts = await Promise.all([
     prisma.contact.create({
       data: {
-        name: "فاطمة خالد",
-        email: "fatima@example.com",
-        phone: "+21891112233",
-        subject: "استفسار عن المنتجات",
-        message: "أريد معرفة المزيد عن مجموعة الخواتم الذهبية وأسعارها",
-        status: "NEW",
+        name: 'فاطمة خالد',
+        email: 'fatima@example.com',
+        phone: '+21891112233',
+        subject: 'استفسار عن المنتجات',
+        message: 'أريد معرفة المزيد عن مجموعة الخواتم الذهبية وأسعارها',
+        status: 'NEW',
       },
     }),
     prisma.contact.create({
       data: {
-        name: "محمد عبدالله",
-        email: "mohammed@example.com",
-        phone: "+21894433221",
-        subject: "طلب عرض سعر خاص",
-        message: "أرغب في الحصول على عرض سعر خاص لطقم كامل من المجوهرات",
-        status: "REPLIED",
+        name: 'محمد عبدالله',
+        email: 'mohammed@example.com',
+        phone: '+21894433221',
+        subject: 'طلب عرض سعر خاص',
+        message: 'أرغب في الحصول على عرض سعر خاص لطقم كامل من المجوهرات',
+        status: 'REPLIED',
+      },
+    }),
+    prisma.contact.create({
+      data: {
+        name: 'Aisha Al-Mansouri',
+        email: 'aisha@example.com',
+        phone: '+218923334455',
+        subject: 'متابعة حالة الطلب',
+        message:
+          'أود التأكد من موعد تسليم طلبي الأخير وشكر الفريق على الخدمة الممتازة',
+        status: 'RESOLVED',
       },
     }),
   ]);
@@ -182,20 +359,20 @@ async function main() {
   const orders = await Promise.all([
     prisma.order.create({
       data: {
-        customerName: "سارة أحمد محمد",
-        customerPhone: "+218911234567",
-        customerEmail: "sara@example.com",
+        customerName: 'سارة أحمد محمد',
+        customerPhone: '+218911234567',
+        customerEmail: 'sara@example.com',
         shippingAddress: {
-          address: "حي النرجس، شارع الملك فهد، الرياض",
-          city: "الرياض",
-          state: "الرياض",
+          address: 'حي النرجس، شارع الملك فهد، الرياض',
+          city: 'الرياض',
+          state: 'الرياض',
         },
         totalAmount: 1950,
         wrappingCost: 100,
         needsWrapping: true,
-        status: "PROCESSING",
-        paymentStatus: "PAID",
-        notes: "يرجى التغليف بعناية خاصة",
+        status: 'PROCESSING',
+        paymentStatus: 'PAID',
+        notes: 'يرجى التغليف بعناية خاصة',
         items: {
           create: {
             productId: products[0].id,
@@ -208,17 +385,17 @@ async function main() {
     }),
     prisma.order.create({
       data: {
-        customerName: "أحمد محمد علي",
-        customerPhone: "+218947654321",
-        customerEmail: "ahmed@example.com",
+        customerName: 'أحمد محمد علي',
+        customerPhone: '+218947654321',
+        customerEmail: 'ahmed@example.com',
         shippingAddress: {
-          address: "حي الملقا، طريق الملك عبدالعزيز، الرياض",
-          city: "الرياض",
+          address: 'حي الملقا، طريق الملك عبدالعزيز، الرياض',
+          city: 'الرياض',
         },
         totalAmount: 3200,
         needsWrapping: false,
-        status: "PENDING",
-        paymentStatus: "PENDING",
+        status: 'PENDING',
+        paymentStatus: 'PENDING',
         items: {
           create: {
             productId: products[1].id,
@@ -229,16 +406,51 @@ async function main() {
         },
       },
     }),
+    prisma.order.create({
+      data: {
+        customerName: 'ليلى عبدالسلام',
+        customerPhone: '+218912223344',
+        customerEmail: 'leila@example.com',
+        shippingAddress: {
+          address: 'طريق الشط، برج الهناء، طرابلس',
+          city: 'طرابلس',
+          state: 'طرابلس',
+        },
+        totalAmount: 4530,
+        wrappingCost: 220,
+        needsWrapping: true,
+        status: 'CONFIRMED',
+        paymentStatus: 'PAID',
+        paymentMethod: 'card',
+        notes: 'الرجاء تضمين بطاقة تهنئة باللغة العربية',
+        items: {
+          create: [
+            {
+              productId: products[5].id,
+              quantity: 1,
+              unitPrice: 2350,
+              totalPrice: 2350,
+            },
+            {
+              productId: products[6].id,
+              quantity: 2,
+              unitPrice: 980,
+              totalPrice: 1960,
+            },
+          ],
+        },
+      },
+    }),
   ]);
 
   console.log(`✅ Created ${orders.length} orders`);
 
-  console.log("🎉 Database seeded successfully!");
+  console.log('🎉 Database seeded successfully!');
 }
 
 main()
   .catch((e) => {
-    console.error("❌ Error seeding database:", e);
+    console.error('❌ Error seeding database:', e);
     process.exit(1);
   })
   .finally(async () => {

--- a/src/components/forms/contact-form.tsx
+++ b/src/components/forms/contact-form.tsx
@@ -35,10 +35,14 @@ export function ContactForm() {
 
   const onSubmit = async (data: CreateContactInput) => {
     try {
-      // Convert undefined phone to null for API compatibility
+      // Trim payload before submitting and normalise optional fields
       const contactData = {
         ...data,
-        phone: data.phone || null,
+        name: data.name.trim(),
+        email: data.email.trim(),
+        subject: data.subject.trim(),
+        message: data.message.trim(),
+        phone: data.phone?.trim() || undefined,
       };
       const submitPromise = createContact(contactData);
 

--- a/src/components/forms/order-form.tsx
+++ b/src/components/forms/order-form.tsx
@@ -1,17 +1,17 @@
-"use client";
+'use client';
 
-import { useAtom } from "jotai";
-import { useState } from "react";
-import { currentLangAtom, cartItemsAtom } from "@/lib/atoms";
-import { createOrder } from "@/lib/api";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
-import { ShoppingCart, Check, AlertCircle } from "lucide-react";
-import Image from "next/image";
-import { formatPrice } from "@/lib/utils";
+import { useAtom } from 'jotai';
+import { useState } from 'react';
+import { currentLangAtom, cartItemsAtom } from '@/lib/atoms';
+import { createOrder } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { ShoppingCart, Check, AlertCircle } from 'lucide-react';
+import Image from 'next/image';
+import { formatPrice } from '@/lib/utils';
 
 interface OrderFormProps {
   onOrderCreated?: (orderId: string) => void;
@@ -19,25 +19,25 @@ interface OrderFormProps {
 
 export function OrderForm({ onOrderCreated }: OrderFormProps) {
   const [currentLang] = useAtom(currentLangAtom);
-  const [cartItems] = useAtom(cartItemsAtom);
+  const [cartItems, setCartItems] = useAtom(cartItemsAtom);
 
   const [formData, setFormData] = useState({
-    customerName: "",
-    customerPhone: "",
-    customerEmail: "",
-    address: "",
-    city: "",
-    state: "",
-    notes: "",
+    customerName: '',
+    customerPhone: '',
+    customerEmail: '',
+    address: '',
+    city: '',
+    state: '',
+    notes: '',
   });
 
   const [needsWrapping, setNeedsWrapping] = useState(false);
   const [paymentMethod, setPaymentMethod] = useState<
-    "card" | "apple_pay" | "stc_pay" | "cod"
-  >("card");
+    'card' | 'apple_pay' | 'stc_pay' | 'cod'
+  >('card');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-  const [submitError, setSubmitError] = useState("");
+  const [submitError, setSubmitError] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   const validateForm = () => {
@@ -45,32 +45,32 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
 
     if (!formData.customerName.trim()) {
       newErrors.customerName =
-        currentLang === "ar" ? "الاسم مطلوب" : "Name is required";
+        currentLang === 'ar' ? 'الاسم مطلوب' : 'Name is required';
     }
 
     if (!formData.customerPhone.trim()) {
       newErrors.customerPhone =
-        currentLang === "ar" ? "رقم الهاتف مطلوب" : "Phone number is required";
+        currentLang === 'ar' ? 'رقم الهاتف مطلوب' : 'Phone number is required';
     }
 
     if (!formData.customerEmail.trim()) {
       newErrors.customerEmail =
-        currentLang === "ar" ? "البريد الإلكتروني مطلوب" : "Email is required";
+        currentLang === 'ar' ? 'البريد الإلكتروني مطلوب' : 'Email is required';
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.customerEmail)) {
       newErrors.customerEmail =
-        currentLang === "ar"
-          ? "بريد إلكتروني غير صحيح"
-          : "Invalid email format";
+        currentLang === 'ar'
+          ? 'بريد إلكتروني غير صحيح'
+          : 'Invalid email format';
     }
 
     if (!formData.address.trim()) {
       newErrors.address =
-        currentLang === "ar" ? "العنوان مطلوب" : "Address is required";
+        currentLang === 'ar' ? 'العنوان مطلوب' : 'Address is required';
     }
 
     if (!formData.city.trim()) {
       newErrors.city =
-        currentLang === "ar" ? "المدينة مطلوبة" : "City is required";
+        currentLang === 'ar' ? 'المدينة مطلوبة' : 'City is required';
     }
 
     setErrors(newErrors);
@@ -80,13 +80,13 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
   const calculateTotal = () => {
     const subtotal = cartItems.reduce(
       (total, item) => total + item.product.price * item.quantity,
-      0,
+      0
     );
     const wrappingCost = needsWrapping
       ? cartItems.reduce(
           (total, item) =>
             total + (item.product.wrappingPrice || 0) * item.quantity,
-          0,
+          0
         )
       : 0;
     const shippingCost = 50; // Fixed shipping cost
@@ -108,13 +108,13 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
 
     if (cartItems.length === 0) {
       setSubmitError(
-        currentLang === "ar" ? "سلة التسوق فارغة" : "Shopping cart is empty",
+        currentLang === 'ar' ? 'سلة التسوق فارغة' : 'Shopping cart is empty'
       );
       return;
     }
 
     setIsSubmitting(true);
-    setSubmitError("");
+    setSubmitError('');
 
     try {
       const totals = calculateTotal();
@@ -122,17 +122,17 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
       const orderData = {
         customerName: formData.customerName,
         customerPhone: formData.customerPhone,
-        customerEmail: formData.customerEmail,
+        customerEmail: formData.customerEmail.trim(),
         shippingAddress: {
-          address: formData.address,
-          city: formData.city,
-          state: formData.state,
+          address: formData.address.trim(),
+          city: formData.city.trim(),
+          state: formData.state.trim() || undefined,
         },
         totalAmount: totals.total,
         wrappingCost: needsWrapping ? totals.wrappingCost : 0,
         needsWrapping,
         paymentMethod,
-        notes: formData.notes,
+        notes: formData.notes.trim() || undefined,
         items: cartItems.map((item) => ({
           productId: item.product.id,
           quantity: item.quantity,
@@ -151,25 +151,28 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
 
         // Reset form
         setFormData({
-          customerName: "",
-          customerPhone: "",
-          customerEmail: "",
-          address: "",
-          city: "",
-          state: "",
-          notes: "",
+          customerName: '',
+          customerPhone: '',
+          customerEmail: '',
+          address: '',
+          city: '',
+          state: '',
+          notes: '',
         });
         setNeedsWrapping(false);
-        setPaymentMethod("card");
+        setPaymentMethod('card');
+
+        // Clear cart items after successful order submission to keep checkout state in sync
+        setCartItems([]);
 
         // Reset submitted state after 5 seconds
         setTimeout(() => setSubmitted(false), 5000);
       }
     } catch {
       setSubmitError(
-        currentLang === "ar"
-          ? "حدث خطأ أثناء إنشاء الطلب. يرجى المحاولة مرة أخرى."
-          : "An error occurred while creating the order. Please try again.",
+        currentLang === 'ar'
+          ? 'حدث خطأ أثناء إنشاء الطلب. يرجى المحاولة مرة أخرى.'
+          : 'An error occurred while creating the order. Please try again.'
       );
     } finally {
       setIsSubmitting(false);
@@ -179,7 +182,7 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
   const handleChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
     if (errors[field]) {
-      setErrors((prev) => ({ ...prev, [field]: "" }));
+      setErrors((prev) => ({ ...prev, [field]: '' }));
     }
   };
 
@@ -193,13 +196,13 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
             <Check className="h-8 w-8 text-green-600" />
           </div>
           <h3 className="text-lg font-semibold text-green-900 mb-2">
-            {currentLang === "ar"
-              ? "تم إنشاء الطلب بنجاح!"
-              : "Order Created Successfully!"}
+            {currentLang === 'ar'
+              ? 'تم إنشاء الطلب بنجاح!'
+              : 'Order Created Successfully!'}
           </h3>
           <p className="text-green-700">
-            {currentLang === "ar"
-              ? "شكراً لطلبك. سنتواصل معك قريباً لتأكيد التفاصيل."
+            {currentLang === 'ar'
+              ? 'شكراً لطلبك. سنتواصل معك قريباً لتأكيد التفاصيل.'
               : "Thank you for your order. We'll contact you soon to confirm the details."}
           </p>
         </CardContent>
@@ -213,14 +216,14 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
         <CardContent className="p-6 text-center">
           <ShoppingCart className="h-16 w-16 text-amber-600 mx-auto mb-4" />
           <h3 className="text-lg font-semibold text-amber-900 mb-2">
-            {currentLang === "ar"
-              ? "سلة التسوق فارغة"
-              : "Shopping Cart is Empty"}
+            {currentLang === 'ar'
+              ? 'سلة التسوق فارغة'
+              : 'Shopping Cart is Empty'}
           </h3>
           <p className="text-amber-700">
-            {currentLang === "ar"
-              ? "يرجى إضافة منتجات إلى السلة قبل المتابعة."
-              : "Please add products to your cart before proceeding."}
+            {currentLang === 'ar'
+              ? 'يرجى إضافة منتجات إلى السلة قبل المتابعة.'
+              : 'Please add products to your cart before proceeding.'}
           </p>
         </CardContent>
       </Card>
@@ -233,7 +236,7 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
       <Card>
         <CardHeader>
           <CardTitle>
-            {currentLang === "ar" ? "معلومات الطلب" : "Order Information"}
+            {currentLang === 'ar' ? 'معلومات الطلب' : 'Order Information'}
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -251,18 +254,18 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
             {/* Customer Name */}
             <div>
               <label className="block text-sm font-medium text-neutral-700 mb-2">
-                {currentLang === "ar" ? "الاسم الكامل" : "Full Name"} *
+                {currentLang === 'ar' ? 'الاسم الكامل' : 'Full Name'} *
               </label>
               <Input
                 type="text"
                 value={formData.customerName}
-                onChange={(e) => handleChange("customerName", e.target.value)}
+                onChange={(e) => handleChange('customerName', e.target.value)}
                 placeholder={
-                  currentLang === "ar"
-                    ? "أدخل اسمك الكامل"
-                    : "Enter your full name"
+                  currentLang === 'ar'
+                    ? 'أدخل اسمك الكامل'
+                    : 'Enter your full name'
                 }
-                className={errors.customerName ? "border-red-300" : ""}
+                className={errors.customerName ? 'border-red-300' : ''}
               />
               {errors.customerName && (
                 <p className="text-red-600 text-sm mt-1">
@@ -274,16 +277,16 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
             {/* Phone */}
             <div>
               <label className="block text-sm font-medium text-neutral-700 mb-2">
-                {currentLang === "ar" ? "رقم الهاتف" : "Phone Number"} *
+                {currentLang === 'ar' ? 'رقم الهاتف' : 'Phone Number'} *
               </label>
               <Input
                 type="tel"
                 value={formData.customerPhone}
-                onChange={(e) => handleChange("customerPhone", e.target.value)}
+                onChange={(e) => handleChange('customerPhone', e.target.value)}
                 placeholder={
-                  currentLang === "ar" ? "+218 91 123 4567" : "+218 91 123 4567"
+                  currentLang === 'ar' ? '+218 91 123 4567' : '+218 91 123 4567'
                 }
-                className={errors.customerPhone ? "border-red-300" : ""}
+                className={errors.customerPhone ? 'border-red-300' : ''}
               />
               {errors.customerPhone && (
                 <p className="text-red-600 text-sm mt-1">
@@ -295,14 +298,14 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
             {/* Email */}
             <div>
               <label className="block text-sm font-medium text-neutral-700 mb-2">
-                {currentLang === "ar" ? "البريد الإلكتروني" : "Email"} *
+                {currentLang === 'ar' ? 'البريد الإلكتروني' : 'Email'} *
               </label>
               <Input
                 type="email"
                 value={formData.customerEmail}
-                onChange={(e) => handleChange("customerEmail", e.target.value)}
+                onChange={(e) => handleChange('customerEmail', e.target.value)}
                 placeholder="example@domain.com"
-                className={errors.customerEmail ? "border-red-300" : ""}
+                className={errors.customerEmail ? 'border-red-300' : ''}
               />
               {errors.customerEmail && (
                 <p className="text-red-600 text-sm mt-1">
@@ -314,17 +317,17 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
             {/* Address */}
             <div>
               <label className="block text-sm font-medium text-neutral-700 mb-2">
-                {currentLang === "ar" ? "العنوان" : "Address"} *
+                {currentLang === 'ar' ? 'العنوان' : 'Address'} *
               </label>
               <Textarea
                 value={formData.address}
-                onChange={(e) => handleChange("address", e.target.value)}
+                onChange={(e) => handleChange('address', e.target.value)}
                 placeholder={
-                  currentLang === "ar"
-                    ? "أدخل عنوانك الكامل"
-                    : "Enter your full address"
+                  currentLang === 'ar'
+                    ? 'أدخل عنوانك الكامل'
+                    : 'Enter your full address'
                 }
-                className={`min-h-[80px] ${errors.address ? "border-red-300" : ""}`}
+                className={`min-h-[80px] ${errors.address ? 'border-red-300' : ''}`}
               />
               {errors.address && (
                 <p className="text-red-600 text-sm mt-1">{errors.address}</p>
@@ -334,14 +337,14 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
             {/* City */}
             <div>
               <label className="block text-sm font-medium text-neutral-700 mb-2">
-                {currentLang === "ar" ? "المدينة" : "City"} *
+                {currentLang === 'ar' ? 'المدينة' : 'City'} *
               </label>
               <Input
                 type="text"
                 value={formData.city}
-                onChange={(e) => handleChange("city", e.target.value)}
-                placeholder={currentLang === "ar" ? "الرياض" : "Riyadh"}
-                className={errors.city ? "border-red-300" : ""}
+                onChange={(e) => handleChange('city', e.target.value)}
+                placeholder={currentLang === 'ar' ? 'الرياض' : 'Riyadh'}
+                className={errors.city ? 'border-red-300' : ''}
               />
               {errors.city && (
                 <p className="text-red-600 text-sm mt-1">{errors.city}</p>
@@ -351,14 +354,14 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
             {/* State */}
             <div>
               <label className="block text-sm font-medium text-neutral-700 mb-2">
-                {currentLang === "ar" ? "المنطقة" : "State/Region"}
+                {currentLang === 'ar' ? 'المنطقة' : 'State/Region'}
               </label>
               <Input
                 type="text"
                 value={formData.state}
-                onChange={(e) => handleChange("state", e.target.value)}
+                onChange={(e) => handleChange('state', e.target.value)}
                 placeholder={
-                  currentLang === "ar" ? "منطقة الرياض" : "Riyadh Region"
+                  currentLang === 'ar' ? 'منطقة الرياض' : 'Riyadh Region'
                 }
               />
             </div>
@@ -376,22 +379,22 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
                 htmlFor="wrapping"
                 className="text-sm font-medium text-neutral-700"
               >
-                {currentLang === "ar" ? "تغليف هدايا" : "Gift Wrapping"}
+                {currentLang === 'ar' ? 'تغليف هدايا' : 'Gift Wrapping'}
               </label>
             </div>
 
             {/* Notes */}
             <div>
               <label className="block text-sm font-medium text-neutral-700 mb-2">
-                {currentLang === "ar" ? "ملاحظات إضافية" : "Additional Notes"}
+                {currentLang === 'ar' ? 'ملاحظات إضافية' : 'Additional Notes'}
               </label>
               <Textarea
                 value={formData.notes}
-                onChange={(e) => handleChange("notes", e.target.value)}
+                onChange={(e) => handleChange('notes', e.target.value)}
                 placeholder={
-                  currentLang === "ar"
-                    ? "أي ملاحظات أو تعليمات خاصة..."
-                    : "Any special notes or instructions..."
+                  currentLang === 'ar'
+                    ? 'أي ملاحظات أو تعليمات خاصة...'
+                    : 'Any special notes or instructions...'
                 }
                 className="min-h-[80px]"
               />
@@ -405,14 +408,14 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
               {isSubmitting ? (
                 <>
                   <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />
-                  {currentLang === "ar"
-                    ? "جاري إنشاء الطلب..."
-                    : "Creating Order..."}
+                  {currentLang === 'ar'
+                    ? 'جاري إنشاء الطلب...'
+                    : 'Creating Order...'}
                 </>
               ) : (
                 <>
                   <ShoppingCart className="h-4 w-4 mr-2" />
-                  {currentLang === "ar" ? "إنشاء الطلب" : "Create Order"}
+                  {currentLang === 'ar' ? 'إنشاء الطلب' : 'Create Order'}
                 </>
               )}
             </Button>
@@ -424,40 +427,40 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
       <Card>
         <CardHeader>
           <CardTitle>
-            {currentLang === "ar" ? "ملخص الطلب" : "Order Summary"}
+            {currentLang === 'ar' ? 'ملخص الطلب' : 'Order Summary'}
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           {/* Payment Methods */}
           <div>
             <p className="text-sm font-medium text-neutral-700 mb-2">
-              {currentLang === "ar" ? "طريقة الدفع" : "Payment Method"}
+              {currentLang === 'ar' ? 'طريقة الدفع' : 'Payment Method'}
             </p>
             <div className="grid grid-cols-2 gap-3">
               {[
                 {
-                  key: "card",
-                  labelAr: "بطاقة بنكية",
-                  labelEn: "Card",
-                  icon: "/orna/visa.svg",
+                  key: 'card',
+                  labelAr: 'بطاقة بنكية',
+                  labelEn: 'Card',
+                  icon: '/orna/visa.svg',
                 },
                 {
-                  key: "apple_pay",
-                  labelAr: "ابل باي",
-                  labelEn: "Apple Pay",
-                  icon: "/orna/apple-pay.svg",
+                  key: 'apple_pay',
+                  labelAr: 'ابل باي',
+                  labelEn: 'Apple Pay',
+                  icon: '/orna/apple-pay.svg',
                 },
                 {
-                  key: "stc_pay",
-                  labelAr: "STC Pay",
-                  labelEn: "STC Pay",
-                  icon: "/orna/unionpay.svg",
+                  key: 'stc_pay',
+                  labelAr: 'STC Pay',
+                  labelEn: 'STC Pay',
+                  icon: '/orna/unionpay.svg',
                 },
                 {
-                  key: "cod",
-                  labelAr: "الدفع عند الاستلام",
-                  labelEn: "Cash on Delivery",
-                  icon: "/orna/mast  ercard.svg",
+                  key: 'cod',
+                  labelAr: 'الدفع عند الاستلام',
+                  labelEn: 'Cash on Delivery',
+                  icon: '/orna/mast  ercard.svg',
                 },
               ].map((m) => (
                 <button
@@ -465,13 +468,13 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
                   type="button"
                   onClick={() =>
                     setPaymentMethod(
-                      m.key as "card" | "apple_pay" | "stc_pay" | "cod",
+                      m.key as 'card' | 'apple_pay' | 'stc_pay' | 'cod'
                     )
                   }
                   className={`flex items-center gap-3 p-3 rounded-lg border transition-colors ${
                     paymentMethod === m.key
-                      ? "border-amber-600 bg-amber-50"
-                      : "border-neutral-200 hover:bg-neutral-50"
+                      ? 'border-amber-600 bg-amber-50'
+                      : 'border-neutral-200 hover:bg-neutral-50'
                   }`}
                 >
                   <div className="relative w-8 h-6">
@@ -483,7 +486,7 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
                     />
                   </div>
                   <span className="text-sm">
-                    {currentLang === "ar" ? m.labelAr : m.labelEn}
+                    {currentLang === 'ar' ? m.labelAr : m.labelEn}
                   </span>
                 </button>
               ))}
@@ -501,14 +504,14 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
                     {item.product.name[currentLang]}
                   </p>
                   <p className="text-xs text-neutral-500">
-                    {currentLang === "ar" ? "الكمية:" : "Qty:"} {item.quantity}
+                    {currentLang === 'ar' ? 'الكمية:' : 'Qty:'} {item.quantity}
                   </p>
                 </div>
                 <p className="font-medium">
                   {formatPrice(
                     item.product.price * item.quantity,
-                    "LYD",
-                    currentLang,
+                    'LYD',
+                    currentLang
                   )}
                 </p>
               </div>
@@ -519,31 +522,31 @@ export function OrderForm({ onOrderCreated }: OrderFormProps) {
           <div className="space-y-2 pt-4 border-t">
             <div className="flex justify-between text-sm">
               <span>
-                {currentLang === "ar" ? "المجموع الفرعي:" : "Subtotal:"}
+                {currentLang === 'ar' ? 'المجموع الفرعي:' : 'Subtotal:'}
               </span>
-              <span>{formatPrice(totals.subtotal, "LYD", currentLang)}</span>
+              <span>{formatPrice(totals.subtotal, 'LYD', currentLang)}</span>
             </div>
 
             {needsWrapping && totals.wrappingCost > 0 && (
               <div className="flex justify-between text-sm">
-                <span>{currentLang === "ar" ? "التغليف:" : "Wrapping:"}</span>
+                <span>{currentLang === 'ar' ? 'التغليف:' : 'Wrapping:'}</span>
                 <span>
-                  {formatPrice(totals.wrappingCost, "LYD", currentLang)}
+                  {formatPrice(totals.wrappingCost, 'LYD', currentLang)}
                 </span>
               </div>
             )}
 
             <div className="flex justify-between text-sm">
-              <span>{currentLang === "ar" ? "الشحن:" : "Shipping:"}</span>
+              <span>{currentLang === 'ar' ? 'الشحن:' : 'Shipping:'}</span>
               <span>
-                {formatPrice(totals.shippingCost, "LYD", currentLang)}
+                {formatPrice(totals.shippingCost, 'LYD', currentLang)}
               </span>
             </div>
 
             <div className="flex justify-between font-semibold text-lg border-t pt-2">
-              <span>{currentLang === "ar" ? "المجموع الكلي:" : "Total:"}</span>
+              <span>{currentLang === 'ar' ? 'المجموع الكلي:' : 'Total:'}</span>
               <span className="text-amber-600">
-                {formatPrice(totals.total, "LYD", currentLang)}
+                {formatPrice(totals.total, 'LYD', currentLang)}
               </span>
             </div>
           </div>

--- a/src/components/layout/hero-carousel.tsx
+++ b/src/components/layout/hero-carousel.tsx
@@ -1,23 +1,23 @@
-"use client";
+'use client';
 
-import { useAtom } from "jotai";
+import { useAtom } from 'jotai';
 import {
   currentLangAtom,
   featuredProductsAtom,
   type Product,
-} from "@/lib/atoms";
+} from '@/lib/atoms';
 import {
   Carousel,
   CarouselContent,
   CarouselItem,
-} from "@/components/ui/carousel";
-import { Button } from "@/components/ui/button";
-import Link from "next/link";
-import { useState, useEffect } from "react";
-import NextImage from "next/image";
-import { createPlaceholderImage } from "@/lib/image-utils";
+} from '@/components/ui/carousel';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+import { useState, useEffect } from 'react';
+import NextImage from 'next/image';
+import { createPlaceholderImage } from '@/lib/image-utils';
 
-import Autoplay from "embla-carousel-autoplay";
+import Autoplay from 'embla-carousel-autoplay';
 
 export function HeroCarousel() {
   const [currentLang] = useAtom(currentLangAtom);
@@ -30,9 +30,9 @@ export function HeroCarousel() {
       title: p.name,
       description: p.description,
       link: `/products/${p.slug}`,
-      image: p.images?.[0] || "/orna/1.jpeg",
-      gradient: "from-amber-600 to-rose-600",
-    }),
+      image: p.images?.[0] || '/orna/1.jpeg',
+      gradient: 'from-amber-600 to-rose-600',
+    })
   );
 
   // Preload images for better performance
@@ -58,11 +58,11 @@ export function HeroCarousel() {
     <div className="relative h-[85vh] md:h-screen w-full overflow-hidden bg-neutral-100">
       <Carousel
         key={currentLang}
-        dir={currentLang === "ar" ? "rtl" : "ltr"}
+        dir={currentLang === 'ar' ? 'rtl' : 'ltr'}
         opts={{
-          align: "start",
+          align: 'start',
           loop: true,
-          direction: currentLang === "ar" ? "rtl" : "ltr",
+          direction: currentLang === 'ar' ? 'rtl' : 'ltr',
         }}
         plugins={[Autoplay({ delay: 5000 })]}
         className="h-full w-full"
@@ -72,14 +72,17 @@ export function HeroCarousel() {
             ? featuredSlides
             : [
                 {
-                  title: { ar: "مرحبا بكم في أورنا", en: "Welcome to Orna" },
-                  description: {
-                    ar: "نص تجريبي للعرض",
-                    en: "Sample hero slide",
+                  title: {
+                    ar: 'اكتشف أناقة مجوهرات أورنا',
+                    en: 'Discover the Elegance of Orna',
                   },
-                  link: "/products",
-                  image: "/orna/3.jpeg",
-                  gradient: "from-amber-600 to-rose-600",
+                  description: {
+                    ar: 'قطع مصممة بعناية من الذهب والأحجار الكريمة للاحتفال بكل لحظة ثمينة في حياتك',
+                    en: 'Thoughtfully crafted gold and gemstone pieces to celebrate every precious moment.',
+                  },
+                  link: '/products',
+                  image: '/orna/3.jpeg',
+                  gradient: 'from-amber-600 to-rose-600',
                 },
               ]
           ).map((slide, index) => (
@@ -89,7 +92,7 @@ export function HeroCarousel() {
                 <NextImage
                   src={slide.image}
                   alt={
-                    typeof slide.title === "string"
+                    typeof slide.title === 'string'
                       ? slide.title
                       : slide.title[currentLang]
                   }
@@ -97,7 +100,7 @@ export function HeroCarousel() {
                   priority={index === 0}
                   sizes="100vw"
                   placeholder="blur"
-                  blurDataURL={createPlaceholderImage(1200, 800, "Orna")}
+                  blurDataURL={createPlaceholderImage(1200, 800, 'Orna')}
                   className="object-cover"
                 />
                 {/* Pearl gradient tint */}
@@ -149,7 +152,7 @@ export function HeroCarousel() {
                           href={slide.link}
                           className="focus-ring rounded-lg"
                         >
-                          {currentLang === "ar" ? "عرض المنتج" : "View Product"}
+                          {currentLang === 'ar' ? 'عرض المنتج' : 'View Product'}
                         </Link>
                       </Button>
                     </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,167 +1,471 @@
-import { Contact, Order, Product } from '@/generated/prisma';
+import type {
+  ApiResponse,
+  Contact,
+  Order,
+  OrderItem,
+  Product,
+} from '@/lib/types';
+import type { CreateContactInput, CreateOrderInput } from '@/lib/validations';
 
-export interface ApiResponse<T> {
-  data?: T;
-  error?: string;
+interface FetchProductsParams {
+  featured?: boolean;
+  search?: string;
+  status?: string;
+  minPrice?: number;
+  maxPrice?: number;
+  page?: number;
+  limit?: number;
+}
+
+interface FetchOrdersParams {
+  status?: string;
+  paymentStatus?: string;
+  customerName?: string;
+  page?: number;
+  limit?: number;
+}
+
+interface FetchContactsParams {
+  status?: string;
+  page?: number;
+  limit?: number;
+}
+
+interface ApiSuccessEnvelope<T> {
+  data: T;
+  message?: string;
+  pagination?: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+const JSON_HEADERS: HeadersInit = {
+  'Content-Type': 'application/json',
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toRecordOfStrings(value: unknown): Record<string, string> {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter(([, v]) => typeof v === 'string')
+  ) as Record<string, string>;
+}
+
+function toOptionalLocalized(
+  value: unknown
+): Record<string, string> | undefined {
+  const localized = toRecordOfStrings(value);
+  return Object.keys(localized).length > 0 ? localized : undefined;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function parseDate(value: unknown): Date {
+  if (value instanceof Date) {
+    return value;
+  }
+
+  const date = new Date(
+    typeof value === 'string' ? value : String(value ?? '')
+  );
+  return Number.isNaN(date.valueOf()) ? new Date() : date;
+}
+
+function normalizeProduct(payload: unknown): Product {
+  if (!isRecord(payload)) {
+    throw new Error('Invalid product payload received from server');
+  }
+
+  return {
+    id: String(payload.id ?? ''),
+    name: toRecordOfStrings(payload.name),
+    slug: String(payload.slug ?? ''),
+    price:
+      typeof payload.price === 'number'
+        ? payload.price
+        : Number(payload.price ?? 0),
+    priceBeforeDiscount:
+      payload.priceBeforeDiscount !== null &&
+      payload.priceBeforeDiscount !== undefined
+        ? Number(payload.priceBeforeDiscount)
+        : undefined,
+    images: toStringArray(payload.images),
+    description: toRecordOfStrings(payload.description),
+    subtitle: toOptionalLocalized(payload.subtitle),
+    subdescription: toOptionalLocalized(payload.subdescription),
+    featured: Boolean(payload.featured),
+    wrappingPrice:
+      payload.wrappingPrice !== null && payload.wrappingPrice !== undefined
+        ? Number(payload.wrappingPrice)
+        : undefined,
+    stockQuantity:
+      typeof payload.stockQuantity === 'number'
+        ? payload.stockQuantity
+        : undefined,
+    status:
+      typeof payload.status === 'string'
+        ? (payload.status as Product['status'])
+        : 'ACTIVE',
+    createdAt: parseDate(payload.createdAt),
+    updatedAt: parseDate(payload.updatedAt),
+  };
+}
+
+function normalizeContact(payload: unknown): Contact {
+  if (!isRecord(payload)) {
+    throw new Error('Invalid contact payload received from server');
+  }
+
+  const phone =
+    typeof payload.phone === 'string' && payload.phone.trim().length > 0
+      ? payload.phone
+      : undefined;
+
+  return {
+    id: String(payload.id ?? ''),
+    name: String(payload.name ?? ''),
+    email: String(payload.email ?? ''),
+    phone,
+    subject: String(payload.subject ?? ''),
+    message: String(payload.message ?? ''),
+    status:
+      typeof payload.status === 'string'
+        ? (payload.status as Contact['status'])
+        : 'NEW',
+    createdAt: parseDate(payload.createdAt),
+    updatedAt: parseDate(payload.updatedAt),
+  };
+}
+
+function normalizeOrderItem(payload: unknown): OrderItem {
+  if (!isRecord(payload)) {
+    throw new Error('Invalid order item payload received from server');
+  }
+
+  return {
+    id: String(payload.id ?? ''),
+    quantity:
+      typeof payload.quantity === 'number'
+        ? payload.quantity
+        : Number(payload.quantity ?? 0),
+    unitPrice:
+      typeof payload.unitPrice === 'number'
+        ? payload.unitPrice
+        : Number(payload.unitPrice ?? 0),
+    totalPrice:
+      typeof payload.totalPrice === 'number'
+        ? payload.totalPrice
+        : Number(payload.totalPrice ?? 0),
+    product: normalizeProduct(payload.product),
+  };
+}
+
+function normalizeOrder(payload: unknown): Order {
+  if (!isRecord(payload)) {
+    throw new Error('Invalid order payload received from server');
+  }
+
+  const shippingAddress = isRecord(payload.shippingAddress)
+    ? Object.fromEntries(
+        Object.entries(payload.shippingAddress).filter(
+          ([, value]) => typeof value === 'string' && value.trim().length > 0
+        )
+      )
+    : {};
+
+  const customerEmail =
+    typeof payload.customerEmail === 'string' &&
+    payload.customerEmail.trim().length > 0
+      ? payload.customerEmail
+      : undefined;
+
+  const paymentUrl =
+    typeof payload.paymentUrl === 'string' && payload.paymentUrl.length > 0
+      ? payload.paymentUrl
+      : undefined;
+
+  const paymentMethod =
+    typeof payload.paymentMethod === 'string' &&
+    payload.paymentMethod.length > 0
+      ? payload.paymentMethod
+      : undefined;
+
+  const notes =
+    typeof payload.notes === 'string' && payload.notes.trim().length > 0
+      ? payload.notes
+      : undefined;
+
+  const items = Array.isArray(payload.items)
+    ? payload.items.map(normalizeOrderItem)
+    : [];
+
+  return {
+    id: String(payload.id ?? ''),
+    orderNumber: String(payload.orderNumber ?? ''),
+    customerName: String(payload.customerName ?? ''),
+    customerPhone: String(payload.customerPhone ?? ''),
+    customerEmail,
+    shippingAddress,
+    totalAmount:
+      typeof payload.totalAmount === 'number'
+        ? payload.totalAmount
+        : Number(payload.totalAmount ?? 0),
+    wrappingCost:
+      payload.wrappingCost !== null && payload.wrappingCost !== undefined
+        ? Number(payload.wrappingCost)
+        : undefined,
+    needsWrapping: Boolean(payload.needsWrapping),
+    paymentStatus:
+      typeof payload.paymentStatus === 'string'
+        ? (payload.paymentStatus as Order['paymentStatus'])
+        : 'PENDING',
+    paymentUrl,
+    paymentMethod,
+    status:
+      typeof payload.status === 'string'
+        ? (payload.status as Order['status'])
+        : 'PENDING',
+    notes,
+    createdAt: parseDate(payload.createdAt),
+    updatedAt: parseDate(payload.updatedAt),
+    items,
+  };
+}
+
+function extractErrorMessage(body: unknown, response: Response): string {
+  if (isRecord(body)) {
+    if (typeof body.error === 'string' && body.error.trim().length > 0) {
+      return body.error;
+    }
+    if (typeof body.message === 'string' && body.message.trim().length > 0) {
+      return body.message;
+    }
+  }
+
+  return `Request failed with status ${response.status}`;
+}
+
+function parsePagination(value: unknown): ApiResponse<unknown>['pagination'] {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const { page, limit, total, totalPages } = value;
+  if (
+    typeof page === 'number' &&
+    typeof limit === 'number' &&
+    typeof total === 'number' &&
+    typeof totalPages === 'number'
+  ) {
+    return { page, limit, total, totalPages };
+  }
+
+  return undefined;
+}
+
+async function parseResponse<T>(
+  response: Response,
+  transform: (payload: unknown) => T
+): Promise<ApiResponse<T>> {
+  let body: unknown = null;
+
+  try {
+    body = await response.json();
+  } catch (error) {
+    if (response.status !== 204) {
+      return {
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to parse server response',
+      };
+    }
+  }
+
+  if (!response.ok) {
+    return { error: extractErrorMessage(body, response) };
+  }
+
+  if (!isRecord(body)) {
+    return { error: 'Malformed server response received' };
+  }
+
+  const payload =
+    'data' in body ? (body as ApiSuccessEnvelope<unknown>).data : body;
+
+  let data: T;
+  try {
+    data = transform(payload);
+  } catch (error) {
+    return {
+      error:
+        error instanceof Error
+          ? error.message
+          : 'Failed to transform server response',
+    };
+  }
+
+  const message = typeof body.message === 'string' ? body.message : undefined;
+  const pagination = parsePagination(body.pagination);
+
+  return { data, message, pagination };
 }
 
 // Products API
-export async function fetchProducts(params?: {
-  featured?: boolean;
-  search?: string;
-  limit?: number;
-}): Promise<ApiResponse<Product[]>> {
-  try {
-    const searchParams = new URLSearchParams();
-    if (params?.featured) searchParams.set('featured', 'true');
-    if (params?.search) searchParams.set('search', params.search);
-    if (params?.limit) searchParams.set('limit', params.limit.toString());
+export async function fetchProducts(
+  params?: FetchProductsParams
+): Promise<ApiResponse<Product[]>> {
+  const searchParams = new URLSearchParams();
 
-    const response = await fetch(`/api/products?${searchParams}`);
-    if (!response.ok) {
-      throw new Error('Failed to fetch products');
+  if (params?.featured !== undefined) {
+    searchParams.set('featured', String(params.featured));
+  }
+  if (params?.search) {
+    searchParams.set('search', params.search);
+  }
+  if (params?.status) {
+    searchParams.set('status', params.status);
+  }
+  if (params?.minPrice !== undefined) {
+    searchParams.set('minPrice', String(params.minPrice));
+  }
+  if (params?.maxPrice !== undefined) {
+    searchParams.set('maxPrice', String(params.maxPrice));
+  }
+  if (params?.page !== undefined) {
+    searchParams.set('page', String(params.page));
+  }
+  if (params?.limit !== undefined) {
+    searchParams.set('limit', String(params.limit));
+  }
+
+  const query = searchParams.toString();
+  const response = await fetch(`/api/products${query ? `?${query}` : ''}`);
+
+  return parseResponse(response, (payload) => {
+    if (!Array.isArray(payload)) {
+      throw new Error('Expected product list in server response');
     }
 
-    const data = await response.json();
-    return { data };
-  } catch (error) {
-    return { error: error instanceof Error ? error.message : 'Unknown error' };
-  }
+    return payload.map(normalizeProduct);
+  });
 }
 
 export async function fetchProduct(id: string): Promise<ApiResponse<Product>> {
-  try {
-    const response = await fetch(`/api/products/${id}`);
-    if (!response.ok) {
-      throw new Error('Failed to fetch product');
-    }
+  const response = await fetch(`/api/products/${id}`);
 
-    const data = await response.json();
-    return { data };
-  } catch (error) {
-    return { error: error instanceof Error ? error.message : 'Unknown error' };
-  }
+  return parseResponse(response, normalizeProduct);
 }
 
 export async function fetchProductBySlug(
   slug: string
 ): Promise<ApiResponse<Product>> {
-  try {
-    const response = await fetch(`/api/products/slug/${slug}`);
-    if (!response.ok) {
-      throw new Error('Failed to fetch product');
-    }
+  const response = await fetch(`/api/products/slug/${slug}`);
 
-    const data = await response.json();
-    return { data };
-  } catch (error) {
-    return { error: error instanceof Error ? error.message : 'Unknown error' };
-  }
+  return parseResponse(response, normalizeProduct);
 }
 
 // Orders API
-export async function fetchOrders(params?: {
-  status?: string;
-  paymentStatus?: string;
-  limit?: number;
-}): Promise<ApiResponse<Order[]>> {
-  try {
-    const searchParams = new URLSearchParams();
-    if (params?.status) searchParams.set('status', params.status);
-    if (params?.paymentStatus)
-      searchParams.set('paymentStatus', params.paymentStatus);
-    if (params?.limit) searchParams.set('limit', params.limit.toString());
+export async function fetchOrders(
+  params?: FetchOrdersParams
+): Promise<ApiResponse<Order[]>> {
+  const searchParams = new URLSearchParams();
 
-    const response = await fetch(`/api/orders?${searchParams}`, {
-      credentials: 'include', // Include cookies for authentication
-    });
-    if (!response.ok) {
-      throw new Error('Failed to fetch orders');
+  if (params?.status) {
+    searchParams.set('status', params.status);
+  }
+  if (params?.paymentStatus) {
+    searchParams.set('paymentStatus', params.paymentStatus);
+  }
+  if (params?.customerName) {
+    searchParams.set('customerName', params.customerName);
+  }
+  if (params?.page !== undefined) {
+    searchParams.set('page', String(params.page));
+  }
+  if (params?.limit !== undefined) {
+    searchParams.set('limit', String(params.limit));
+  }
+
+  const query = searchParams.toString();
+  const response = await fetch(`/api/orders${query ? `?${query}` : ''}`, {
+    credentials: 'include',
+  });
+
+  return parseResponse(response, (payload) => {
+    if (!Array.isArray(payload)) {
+      throw new Error('Expected order list in server response');
     }
 
-    const data = await response.json();
-    return { data };
-  } catch (error) {
-    return { error: error instanceof Error ? error.message : 'Unknown error' };
-  }
+    return payload.map(normalizeOrder);
+  });
 }
 
 export async function createOrder(
-  orderData: Omit<
-    Order,
-    | 'id'
-    | 'status'
-    | 'createdAt'
-    | 'updatedAt'
-    | 'orderNumber'
-    | 'paymentStatus'
-    | 'paymentUrl'
-    | 'customerId'
-  >
+  orderData: CreateOrderInput
 ): Promise<ApiResponse<Order>> {
-  try {
-    const response = await fetch('/api/orders', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(orderData),
-    });
+  const response = await fetch('/api/orders', {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(orderData),
+  });
 
-    if (!response.ok) {
-      throw new Error('Failed to create order');
-    }
-
-    const data = await response.json();
-    return { data };
-  } catch (error) {
-    return { error: error instanceof Error ? error.message : 'Unknown error' };
-  }
+  return parseResponse(response, normalizeOrder);
 }
 
 // Contacts API
-export async function fetchContacts(params?: {
-  status?: string;
-  limit?: number;
-}): Promise<ApiResponse<Contact[]>> {
-  try {
-    const searchParams = new URLSearchParams();
-    if (params?.status) searchParams.set('status', params.status);
-    if (params?.limit) searchParams.set('limit', params.limit.toString());
+export async function fetchContacts(
+  params?: FetchContactsParams
+): Promise<ApiResponse<Contact[]>> {
+  const searchParams = new URLSearchParams();
 
-    const response = await fetch(`/api/contacts?${searchParams}`, {
-      credentials: 'include', // Include cookies for authentication
-    });
-    if (!response.ok) {
-      throw new Error('Failed to fetch contacts');
+  if (params?.status) {
+    searchParams.set('status', params.status);
+  }
+  if (params?.page !== undefined) {
+    searchParams.set('page', String(params.page));
+  }
+  if (params?.limit !== undefined) {
+    searchParams.set('limit', String(params.limit));
+  }
+
+  const query = searchParams.toString();
+  const response = await fetch(`/api/contacts${query ? `?${query}` : ''}`, {
+    credentials: 'include',
+  });
+
+  return parseResponse(response, (payload) => {
+    if (!Array.isArray(payload)) {
+      throw new Error('Expected contact list in server response');
     }
 
-    const data = await response.json();
-    return { data };
-  } catch (error) {
-    return { error: error instanceof Error ? error.message : 'Unknown error' };
-  }
+    return payload.map(normalizeContact);
+  });
 }
 
 export async function createContact(
-  contactData: Pick<Contact, 'name' | 'email' | 'phone' | 'subject' | 'message'>
+  contactData: CreateContactInput
 ): Promise<ApiResponse<Contact>> {
-  try {
-    const response = await fetch('/api/contacts', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(contactData),
-    });
+  const response = await fetch('/api/contacts', {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body: JSON.stringify(contactData),
+  });
 
-    if (!response.ok) {
-      throw new Error('Failed to create contact');
-    }
-
-    const data = await response.json();
-    return { data };
-  } catch (error) {
-    return { error: error instanceof Error ? error.message : 'Unknown error' };
-  }
+  return parseResponse(response, normalizeContact);
 }

--- a/src/lib/atoms.ts
+++ b/src/lib/atoms.ts
@@ -1,88 +1,24 @@
 import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 import { fetchProducts, fetchOrders, fetchContacts } from './api';
+import type {
+  Product,
+  Order,
+  Contact,
+  SettingKV,
+  CartItem,
+  User,
+} from './types';
 
-// Types
-export interface Product {
-  id: string;
-  name: Record<string, string>;
-  slug: string;
-  price: number;
-  priceBeforeDiscount?: number;
-  images: string[];
-  description: Record<string, string>;
-  subtitle?: Record<string, string>;
-  subdescription?: Record<string, string>;
-  featured: boolean;
-  wrappingPrice?: number;
-  status: 'ACTIVE' | 'INACTIVE' | 'OUT_OF_STOCK';
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-export interface Order {
-  id: string;
-  orderNumber: string;
-  customerName: string;
-  customerPhone: string;
-  customerEmail?: string;
-  shippingAddress: Record<string, string>;
-  totalAmount: number;
-  wrappingCost?: number;
-  needsWrapping: boolean;
-  paymentStatus: 'PENDING' | 'PAID' | 'FAILED' | 'REFUNDED';
-  paymentUrl?: string;
-  paymentMethod?: string;
-  status:
-    | 'PENDING'
-    | 'CONFIRMED'
-    | 'PROCESSING'
-    | 'SHIPPED'
-    | 'DELIVERED'
-    | 'CANCELLED';
-  notes?: string;
-  createdAt: Date;
-  updatedAt: Date;
-  items: OrderItem[];
-}
-
-export interface OrderItem {
-  id: string;
-  quantity: number;
-  unitPrice: number;
-  totalPrice: number;
-  product: Product;
-}
-
-export interface Contact {
-  id: string;
-  name: string;
-  email: string;
-  phone?: string;
-  subject: string;
-  message: string;
-  status: 'NEW' | 'REPLIED' | 'RESOLVED';
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-export interface SettingKV<T = unknown> {
-  key: string;
-  value: T;
-}
-
-export interface User {
-  id: string;
-  email: string;
-  name?: string;
-  role: 'USER' | 'ADMIN' | 'SUPER_ADMIN';
-  image?: string;
-}
-
-export interface CartItem {
-  product: Product;
-  quantity: number;
-}
+export type {
+  Product,
+  Order,
+  Contact,
+  SettingKV,
+  CartItem,
+  User,
+} from './types';
+export type { OrderItem } from './types';
 
 // Global State Atoms
 export const currentLangAtom = atomWithStorage<string>('currentLang', 'ar');
@@ -135,7 +71,7 @@ export const loadProductsAtom = atom(null, async (get, set) => {
   try {
     const result = await fetchProducts();
     if (result.data) {
-      set(productsAtom, result.data as Product[]);
+      set(productsAtom, result.data);
     } else {
       console.error('Failed to load products:', result.error);
       set(productsErrorAtom, result.error || 'Failed to load products');
@@ -154,8 +90,7 @@ export const loadOrdersAtom = atom(null, async (get, set) => {
   try {
     const result = await fetchOrders();
     if (result.data) {
-      // TODO: fix this typing
-      set(ordersAtom, result.data as unknown as Order[]);
+      set(ordersAtom, result.data);
     } else {
       console.error('Failed to load orders:', result.error);
       set(ordersErrorAtom, result.error || 'Failed to load orders');
@@ -174,7 +109,7 @@ export const loadContactsAtom = atom(null, async (get, set) => {
   try {
     const result = await fetchContacts();
     if (result.data) {
-      set(contactsAtom, result.data as Contact[]);
+      set(contactsAtom, result.data);
     } else {
       console.error('Failed to load contacts:', result.error);
       set(contactsErrorAtom, result.error || 'Failed to load contacts');

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,6 +20,7 @@ export interface Product {
   subdescription?: Record<string, string>;
   featured: boolean;
   wrappingPrice?: number;
+  stockQuantity?: number;
   status: 'ACTIVE' | 'INACTIVE' | 'OUT_OF_STOCK';
   createdAt: Date;
   updatedAt: Date;

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -46,8 +46,9 @@ export const createOrderSchema = z.object({
   customerPhone: z.string().min(1, 'Customer phone is required'),
   customerEmail: z.string().email('Invalid email').optional(),
   shippingAddress: z.object({
-    ar: z.string().min(1, 'Arabic address is required'),
-    en: z.string().optional(),
+    address: z.string().min(1, 'Shipping address is required'),
+    city: z.string().min(1, 'City is required'),
+    state: z.string().optional(),
   }),
   totalAmount: z.number().min(0, 'Total amount must be positive'),
   wrappingCost: z.number().min(0).optional(),


### PR DESCRIPTION
## Summary
- normalize API client responses and update atoms to work with typed data and pagination-aware envelopes
- align order and contact forms with trimmed payloads and refined validations while updating hero fallback content
- expand the Prisma seed with richer storefront settings plus additional catalog, contact, and order records

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68d59f981c88832cacc2409fcaf42b20